### PR TITLE
Overload the `jsx-a11y/label-has-associated-control` rule configurati…

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,13 @@ module.exports = {
         'import/order': ['error', {
             groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index']
         }],
+        'jsx-a11y/label-has-associated-control': ['error', {
+            labelComponents: [],
+            labelAttributes: [],
+            controlComponents: [],
+            assert: 'either',
+            depth: 25
+        }],
         'max-len': ['error', {
           code: 120,
           ignoreTrailingComments: true,


### PR DESCRIPTION
…on to allow associating `<label>` to input fields by nesting only

According to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label nesting is enough.

> Alternatively, you can nest the <input> directly inside the <label>, in which case the for and id attributes are not needed because the association is implicit.

Rule config in airbnb standard: https://github.com/airbnb/javascript/blob/d5d406a849f03b8ce1bc8848acb7ef1690d29c85/packages/eslint-config-airbnb/rules/react-a11y.js#L123